### PR TITLE
Use edge runtime for schedule API routes

### DIFF
--- a/utils/transiterUtils.ts
+++ b/utils/transiterUtils.ts
@@ -17,7 +17,7 @@ export async function getNearbyStops(
   latitude: string,
   longitude: string,
   max_distance_km: number | string,
-  limit?: number | number
+  limit?: number | number | null
 ) {
   const stopsDataResp = await fetch(
     `${TRANSITER_URL}/systems/${system}/stops?` +


### PR DESCRIPTION
This change moves the core schedule API routes to the Vercel edge runtime. This should theoretically decrease function boot time, since these are all thin wrappers around Transiter APIs.

In addition to changing the runtime declaration, a few code changes needed to be made to make the functions compliant with the Web Standards API that is required by the edge runtime:

1. `NextApiRequest` and `NextApiResponse` had to be replaced by `Request` and `Response`, respectively.
2. `Response` objects need to be returned directly instead of modifying the `NextApiResponse` previously passed into the functions.
3. Query parameters need to be parsed using the `searchParams` of the URL instead of using the `query` parameter on the request object (see: https://github.com/vercel/next.js/discussions/40468#discussioncomment-4130287).